### PR TITLE
Split slide deck 08 into 08a and 08b to match lab structure

### DIFF
--- a/docs/07_Recording_Rules_Alerting/index.html
+++ b/docs/07_Recording_Rules_Alerting/index.html
@@ -574,9 +574,9 @@ Together, these benefits make recording rules an essential tool for scaling and 
                     <textarea data-template>
                         # 🌟 Great job!
                         
-                        Continue to Lab 8: Advanced PromQL Operations
+                        Continue to Lab 8a: Label Manipulation & Offset
                         
-                        <small>Navigate: [All Slides](../index.html) | [Next Lab](../08_Advanced_PromQL_Operations/index.html)</small>
+                        <small>Navigate: [All Slides](../index.html) | [Next Lab](../08a_Label_Manipulation_Offset/index.html)</small>
                         
 <aside class="notes">
 Congratulations! You've completed Lab 7 on Recording Rules and Alerting, which represents a significant step in your Prometheus journey.
@@ -587,7 +587,7 @@ These concepts are essential building blocks for production-grade monitoring sys
 
 As your monitoring needs grow more sophisticated, the practices you've learned today will become increasingly valuable. Recording rules will help you maintain performance as your metrics volume increases, and well-designed alerts will ensure that you're notified about important issues without being overwhelmed by false alarms.
 
-In the next lab, we'll build on these foundations by exploring advanced PromQL operations that allow for even more sophisticated analysis and monitoring. You'll learn techniques that expand the expressive power of your queries and enable new insights into your systems.
+In Lab 8a, we'll explore label manipulation functions and the offset modifier, which allow you to transform labels and compare metrics across time periods. These are foundational techniques for advanced monitoring scenarios.
 
 Before moving on, make sure you're comfortable with the material we've covered. Try creating your own recording and alert rules beyond the examples we've discussed, and experiment with different thresholds and durations to get a feel for how they affect alert behavior.
 </aside>

--- a/docs/08a_Label_Manipulation_Offset/index.html
+++ b/docs/08a_Label_Manipulation_Offset/index.html
@@ -1,0 +1,437 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Lab 8a: Label Manipulation & Offset</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.3.1/reveal.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.3.1/theme/black.min.css">
+    <link rel="stylesheet" href="../common.css">
+</head>
+<body>
+    <div class="reveal">
+        <div class="slides">
+            <section data-markdown>
+                <textarea data-template>
+                    # 🏷️ Lab 8a: Label Manipulation & Offset
+                    
+                    Transform labels and compare metrics across time
+                    
+<aside class="notes">
+Welcome to Lab 8a, which focuses on two essential PromQL capabilities: label manipulation and the offset modifier.
+
+These features give you powerful control over how your metrics are organized and how you can compare them across time periods.
+
+Label manipulation allows you to transform, add, and combine metric labels at query time - giving you flexibility without changing your instrumentation.
+
+The offset modifier lets you look back in time and compare current values with historical data - essential for trend analysis and anomaly detection.
+
+Mastering these techniques will significantly enhance your ability to create meaningful queries and insights.
+</aside>
+                </textarea>
+            </section>
+
+            <section data-markdown>
+                <textarea data-template>
+                    ## Lab Objectives
+                    
+                    By the end of this lab, you will be able to:
+                    
+                    * Transform labels using **label_replace()** and **label_join()**
+                    * Use regex capture groups for sophisticated label transformations
+                    * Compare current values with historical data using **offset**
+                    * Implement time-shifted comparisons for trend analysis
+                    
+<aside class="notes">
+In this lab, we'll focus on two core advanced PromQL techniques:
+
+First, label manipulation functions - specifically label_replace and label_join. These functions allow you to transform metric labels at query time, which is incredibly useful when you need to reshape your data for joins, create derived labels, or standardize label formats across different metrics.
+
+Second, the offset modifier, which allows you to compare current metric values with historical values. This is essential for trend analysis, week-over-week comparisons, and detecting anomalies based on historical patterns.
+
+Both of these techniques are foundational for more advanced monitoring scenarios and will prepare you for the concepts we'll cover in Lab 8b.
+</aside>
+                </textarea>
+            </section>
+
+            <section data-markdown>
+                <textarea data-template>
+                    ## Label Manipulation Functions
+                    
+                    PromQL provides functions to transform labels at query time:
+                    
+                    * **label_replace()**: Transform or create labels using regex
+                    * **label_join()**: Combine multiple labels into one
+                    
+                    These functions let you:
+                    * Standardize label names across different metrics
+                    * Extract parts of labels for grouping
+                    * Create derived labels for joins and aggregations
+                    
+<aside class="notes">
+PromQL provides two powerful functions for manipulating labels at query time: label_replace and label_join.
+
+The label_replace function allows you to transform existing labels or create new ones using regular expressions. This is incredibly versatile - you can extract portions of a label, transform formats, or add entirely new labels based on patterns in existing ones.
+
+The label_join function combines multiple labels into a single new label, which is useful for creating composite keys or generating human-readable combined identifiers.
+
+Why would you need these functions? There are several common scenarios:
+
+First, standardizing labels across different metrics. When you have metrics from different sources, they might use different naming conventions. Label manipulation lets you align them for easier querying.
+
+Second, extracting parts of labels. If you have a label like "namespace/deployment/pod", you might want to extract just the deployment name for aggregation.
+
+Third, creating derived labels for joins. When you need to join two metrics but their labels don't quite match, you can use these functions to create compatible label sets.
+
+Let's explore each function in detail.
+</aside>
+                </textarea>
+            </section>
+
+            <section data-markdown>
+                <textarea data-template>
+                    ## label_replace() Function
+                    
+                    ```promql
+                    label_replace(
+                      vector,
+                      "dest_label",
+                      "replacement",
+                      "source_label",
+                      "regex"
+                    )
+                    ```
+                    
+                    * **vector**: Input time series
+                    * **dest_label**: Label to create/modify
+                    * **replacement**: New value (can use capture groups)
+                    * **source_label**: Label to match against
+                    * **regex**: Pattern to match (with capture groups)
+                    
+<aside class="notes">
+The label_replace function is the more powerful of the two label manipulation functions. It takes five parameters:
+
+First, the vector - the input time series you want to transform.
+
+Second, the destination label - the name of the label you want to create or modify.
+
+Third, the replacement string - the new value for the label, which can include references to regex capture groups using $1, $2, etc.
+
+Fourth, the source label - the existing label you want to match against.
+
+Fifth, the regex - the pattern to match against the source label, typically including capture groups in parentheses.
+
+If the regex matches the source label value, the destination label is set to the replacement string. If it doesn't match, the time series is returned unchanged.
+
+The key power here is the combination of regex capture groups and the replacement string. You can extract specific parts of a label value, transform them, and create entirely new labels.
+
+For example, if you have an instance label like "server-prod-01.example.com:9100", you could extract just "prod" into a new "environment" label using a carefully crafted regex.
+</aside>
+                </textarea>
+            </section>
+
+            <section data-markdown>
+                <textarea data-template>
+                    ## label_replace() Examples
+                    
+                    **Extract environment from instance name:**
+                    ```promql
+                    label_replace(
+                      node_cpu_seconds_total,
+                      "environment",
+                      "$1",
+                      "instance",
+                      ".*-(prod|staging|dev)-.*"
+                    )
+                    ```
+                    
+                    **Create a short hostname:**
+                    ```promql
+                    label_replace(
+                      up,
+                      "short_host",
+                      "$1",
+                      "instance",
+                      "([^:]+):.*"
+                    )
+                    ```
+                    
+<aside class="notes">
+Let's look at some practical examples of label_replace in action.
+
+The first example extracts an environment designation from an instance name. If your instances follow a naming pattern like "app-prod-01" or "db-staging-02", this query extracts the environment part into a new label.
+
+The regex ".*-(prod|staging|dev)-.*" matches any string containing one of these environment names, and the capture group around them lets us extract just that part. The $1 in the replacement refers to the first capture group.
+
+The second example creates a short hostname from the full instance address. The regex "([^:]+):.*" captures everything before the colon (the hostname) and discards the port number. This is useful when you want to group metrics by hostname without the port.
+
+Some important notes about label_replace:
+- If the regex doesn't match, the original time series is returned unchanged (the destination label is not added)
+- You can use $0 to reference the entire matched string
+- You can use multiple capture groups ($1, $2, etc.) in the replacement
+- The regex must match the entire source label value, so use .* at the beginning and end if needed
+
+These patterns are essential for creating flexible queries that can adapt to different naming conventions.
+</aside>
+                </textarea>
+            </section>
+
+            <section data-markdown>
+                <textarea data-template>
+                    ## label_join() Function
+                    
+                    ```promql
+                    label_join(
+                      vector,
+                      "dest_label",
+                      "separator",
+                      "source_label1",
+                      "source_label2",
+                      ...
+                    )
+                    ```
+                    
+                    **Example: Create combined identifier**
+                    ```promql
+                    label_join(
+                      up{job="node-exporter"},
+                      "host_job",
+                      " - ",
+                      "instance",
+                      "job"
+                    )
+                    ```
+                    
+                    Creates: `host_job="localhost:9100 - node-exporter"`
+                    
+<aside class="notes">
+The label_join function is simpler than label_replace but very useful for combining multiple labels into one.
+
+It takes the following parameters:
+- The input vector
+- The destination label name
+- A separator string that will be placed between the combined values
+- One or more source labels to combine
+
+The function creates a new label by concatenating the values of all source labels, separated by the specified separator.
+
+In the example shown, we're combining the instance and job labels into a new "host_job" label, separated by " - ". This creates a human-readable combined identifier like "localhost:9100 - node-exporter".
+
+Common use cases for label_join include:
+- Creating composite keys for aggregation
+- Generating human-readable identifiers for dashboards
+- Preparing labels for external systems that expect specific formats
+- Creating unique identifiers when single labels aren't sufficient
+
+The label_join function always creates the destination label (unlike label_replace which only acts when the regex matches). If any source labels don't exist on a time series, they're simply omitted from the result.
+</aside>
+                </textarea>
+            </section>
+
+            <section data-markdown>
+                <textarea data-template>
+                    ## The Offset Modifier
+                    
+                    Compare current values with historical data:
+                    
+                    ```promql
+                    # Current memory usage
+                    node_memory_MemAvailable_bytes
+                    
+                    # Memory usage 1 hour ago
+                    node_memory_MemAvailable_bytes offset 1h
+                    
+                    # Memory usage 1 day ago
+                    node_memory_MemAvailable_bytes offset 1d
+                    ```
+                    
+                    * Shifts all timestamps back by the specified duration
+                    * Works with any instant vector or range vector
+                    * Essential for trend analysis and anomaly detection
+                    
+<aside class="notes">
+The offset modifier is one of the most useful features in PromQL for trend analysis and historical comparisons.
+
+When you add "offset" followed by a duration to a query, Prometheus shifts all the timestamps back by that amount. This lets you query what a metric's value was at some point in the past.
+
+In the examples shown:
+- The first query returns current memory availability
+- The second query returns what memory availability was 1 hour ago
+- The third query returns what it was 1 day ago
+
+The offset modifier works with both instant vectors and range vectors. For example, you could calculate the rate of change from 1 day ago:
+
+```promql
+rate(http_requests_total[5m] offset 1d)
+```
+
+This gives you the request rate from 24 hours ago, which you can then compare with the current rate.
+
+The offset modifier is essential for:
+- Week-over-week or day-over-day comparisons
+- Detecting anomalies by comparing current values to historical baselines
+- Calculating absolute change over time periods
+- Trend analysis and capacity planning
+</aside>
+                </textarea>
+            </section>
+
+            <section data-markdown>
+                <textarea data-template>
+                    ## Offset Use Cases
+                    
+                    **Week-over-week comparison:**
+                    ```promql
+                    rate(http_requests_total[5m]) 
+                    - 
+                    rate(http_requests_total[5m] offset 7d)
+                    ```
+                    
+                    **Percentage change from yesterday:**
+                    ```promql
+                    (node_memory_MemAvailable_bytes 
+                     - node_memory_MemAvailable_bytes offset 1d)
+                    / 
+                    node_memory_MemAvailable_bytes offset 1d * 100
+                    ```
+                    
+                    **Detect unusual activity:**
+                    ```promql
+                    rate(errors_total[5m]) 
+                    > 2 * rate(errors_total[5m] offset 1d)
+                    ```
+                    
+<aside class="notes">
+Let's explore some practical use cases for the offset modifier.
+
+The first example shows a week-over-week comparison of request rates. By subtracting last week's rate from this week's rate, you get the absolute difference. A positive value means traffic is higher than last week; negative means it's lower.
+
+The second example calculates the percentage change in available memory compared to yesterday. This is a classic formula:
+(current - historical) / historical * 100
+
+This tells you what percentage memory has changed, which is more meaningful than the absolute byte difference.
+
+The third example demonstrates anomaly detection. It triggers when the current error rate is more than twice what it was at the same time yesterday. This is a simple but effective way to detect unusual activity.
+
+Some important considerations when using offset:
+- Make sure you have sufficient data retention (you can't query data that's been deleted)
+- Consider the semantic meaning of your comparisons (comparing weekday to weekend might not be meaningful)
+- Account for time zones if your traffic patterns are timezone-dependent
+- Use appropriate durations for your use case (1d for daily patterns, 7d for weekly patterns)
+
+These patterns form the foundation for context-aware alerting that accounts for normal variations in your metrics.
+</aside>
+                </textarea>
+            </section>
+
+            <section data-markdown>
+                <textarea data-template>
+                    ## 🧪 Hands-On Exercise
+                    
+                    Try these queries in the Prometheus UI:
+                    
+                    **1. Extract hostname from instance:**
+                    ```promql
+                    label_replace(up, "hostname", "$1", "instance", "([^:]+):.*")
+                    ```
+                    
+                    **2. Compare current vs historical memory:**
+                    ```promql
+                    node_memory_MemAvailable_bytes 
+                    - node_memory_MemAvailable_bytes offset 5m
+                    ```
+                    
+                    **3. Calculate memory change percentage:**
+                    ```promql
+                    100 * (node_memory_MemAvailable_bytes 
+                    - node_memory_MemAvailable_bytes offset 5m)
+                    / node_memory_MemAvailable_bytes offset 5m
+                    ```
+                    
+<aside class="notes">
+Let's put these concepts into practice with some hands-on exercises.
+
+Exercise 1 demonstrates label_replace to extract the hostname from an instance label. The regex captures everything before the colon, effectively stripping the port number. After running this query, you'll see a new "hostname" label on each time series.
+
+Exercise 2 shows a simple offset comparison - current memory minus memory from 5 minutes ago. The result shows the absolute change in bytes. Positive values mean memory availability increased; negative means it decreased.
+
+Exercise 3 extends this to calculate a percentage change. This is more useful for understanding the magnitude of change relative to the total. A change of 100MB might be significant on a 1GB server but trivial on a 64GB server.
+
+As you run these queries, observe:
+- How the label_replace creates the new label only when the regex matches
+- How offset shifts the data back in time
+- How arithmetic operations work between offset and non-offset queries
+
+These techniques form the foundation for the more advanced topics we'll cover in Lab 8b.
+</aside>
+                </textarea>
+            </section>
+
+            <section data-markdown>
+                <textarea data-template>
+                    ## Summary
+                    
+                    * **label_replace()** transforms labels using regex
+                      - Extract parts of labels with capture groups
+                      - Create derived labels for joins and grouping
+                    
+                    * **label_join()** combines multiple labels into one
+                      - Create composite identifiers
+                      - Generate human-readable combined labels
+                    
+                    * **offset** modifier enables historical comparisons
+                      - Week-over-week and day-over-day analysis
+                      - Anomaly detection based on historical patterns
+                    
+<aside class="notes">
+Let's summarize what we've learned in Lab 8a.
+
+Label manipulation functions give you powerful control over your metric labels at query time:
+
+label_replace is the more powerful function, using regular expressions to transform or create labels. The key capability is using capture groups to extract specific parts of label values and use them in new labels. This is essential for standardizing labels across different metrics and creating derived labels for complex queries.
+
+label_join is simpler but equally useful for combining multiple labels into a single new label. This is great for creating composite identifiers or human-readable combined labels for dashboards.
+
+The offset modifier is essential for any time-based analysis. It lets you compare current values with historical data, enabling:
+- Week-over-week and day-over-day comparisons
+- Percentage change calculations
+- Anomaly detection based on historical patterns
+- Trend analysis for capacity planning
+
+These techniques form the foundation for more advanced PromQL patterns. In Lab 8b, we'll build on these concepts with subqueries, ranking functions, and missing metric detection.
+</aside>
+                </textarea>
+            </section>
+
+            <section data-markdown>
+                <textarea data-template>
+                    # 🌟 Great job!
+                    
+                    Continue to Lab 8b: Subqueries, TopK & Absent
+                    
+                    <small>Navigate: [All Slides](../index.html) | [Next Lab](../08b_Subqueries_TopK_Absent/index.html)</small>
+                    
+<aside class="notes">
+Congratulations on completing Lab 8a! You've learned two essential advanced PromQL techniques:
+
+Label manipulation functions give you the flexibility to reshape your metric labels at query time, enabling more sophisticated joins and aggregations.
+
+The offset modifier opens up powerful historical analysis capabilities, letting you compare current metrics with past values for trend analysis and anomaly detection.
+
+In Lab 8b, we'll continue with more advanced topics:
+- Subqueries for complex time-based analysis
+- The topk and bottomk functions for identifying outliers
+- The absent function for detecting missing metrics
+
+These techniques will complete your advanced PromQL toolkit and prepare you for sophisticated monitoring scenarios.
+
+Take a moment to experiment with label manipulation and offset queries on your own metrics before moving on.
+</aside>
+                </textarea>
+            </section>
+        </div>
+    </div>
+    <!-- Include common scripts -->
+    <script src="../common-scripts.js"></script>
+</body>
+</html>

--- a/docs/08b_Subqueries_TopK_Absent/index.html
+++ b/docs/08b_Subqueries_TopK_Absent/index.html
@@ -1,0 +1,526 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Lab 8b: Subqueries, TopK & Absent</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.3.1/reveal.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.3.1/theme/black.min.css">
+    <link rel="stylesheet" href="../common.css">
+</head>
+<body>
+    <div class="reveal">
+        <div class="slides">
+            <section data-markdown>
+                <textarea data-template>
+                    # 📊 Lab 8b: Subqueries, TopK & Absent
+                    
+                    Advanced time-series analysis and outlier detection
+                    
+<aside class="notes">
+Welcome to Lab 8b, where we'll explore three powerful PromQL features that enable sophisticated monitoring scenarios.
+
+Building on the label manipulation and offset techniques from Lab 8a, we'll now dive into:
+
+Subqueries - allowing you to apply functions to ranges of already-processed data, enabling complex time-series analysis.
+
+Ranking functions (topk/bottomk) - helping you identify the most significant outliers in your metrics.
+
+The absent function - detecting when expected metrics are missing, which is crucial for monitoring your monitoring.
+
+These techniques represent the transition from basic monitoring to sophisticated observability.
+</aside>
+                </textarea>
+            </section>
+
+            <section data-markdown>
+                <textarea data-template>
+                    ## Lab Objectives
+                    
+                    By the end of this lab, you will be able to:
+                    
+                    * Write **subqueries** for complex time-based analysis
+                    * Use **topk()** and **bottomk()** to identify outliers
+                    * Detect missing metrics with **absent()**
+                    * Combine these techniques for sophisticated monitoring
+                    
+<aside class="notes">
+In this lab, we'll cover three advanced PromQL features:
+
+First, subqueries - one of the most powerful features in PromQL. Subqueries let you apply functions like avg_over_time to ranges of already-processed data, enabling analysis like "what was the average of the 5-minute rate over the past hour?"
+
+Second, the topk and bottomk ranking functions. These help you identify the most significant outliers in your metrics - whether that's the top CPU consumers, the slowest endpoints, or the instances with the most errors.
+
+Third, the absent function for detecting missing metrics. This is essential for "monitoring your monitoring" - ensuring that your instrumentation is working correctly and that expected metrics are being reported.
+
+Together, these techniques give you the tools to create context-aware monitoring that goes beyond simple thresholds.
+</aside>
+                </textarea>
+            </section>
+
+            <section data-markdown>
+                <textarea data-template>
+                    ## Understanding Subqueries
+                    
+                    Apply functions over a range of instant vector results:
+                    
+                    ```promql
+                    # Syntax
+                    <instant_query>[<range>:<resolution>]
+                    ```
+                    
+                    * **instant_query**: Any query that returns an instant vector
+                    * **range**: How far back to look (e.g., 1h)
+                    * **resolution**: How often to sample (e.g., 5m)
+                    
+                    **Example:**
+                    ```promql
+                    # Average of 5-minute CPU rates over the past hour
+                    avg_over_time(
+                      sum(rate(node_cpu_seconds_total{mode!="idle"}[5m]))[1h:5m]
+                    )
+                    ```
+                    
+<aside class="notes">
+Subqueries are one of the most powerful features in PromQL. They allow you to take the result of any instant vector query and treat it as if it were a range vector - then apply range vector functions to it.
+
+The syntax adds a range and resolution to any instant query:
+- The range (like 1h) specifies how far back to look
+- The resolution (like 5m) specifies how often to sample the inner query
+
+In the example, we're calculating:
+1. The rate of non-idle CPU time over 5-minute windows
+2. Summing those rates to get total CPU utilization
+3. Then finding the average of those values over the past hour, sampled every 5 minutes
+
+This gives us a smoothed view of CPU utilization that's less susceptible to short-term spikes.
+
+Subqueries are particularly useful when you want to:
+- Calculate moving averages of already-aggregated data
+- Find the max or min of a rate over a longer period
+- Smooth out noisy metrics for alerting
+- Analyze patterns in derived metrics over time
+
+The resolution parameter is important for performance - sampling too frequently can create a lot of data points to process.
+</aside>
+                </textarea>
+            </section>
+
+            <section data-markdown>
+                <textarea data-template>
+                    ## Subquery Examples
+                    
+                    **Moving average of request rate:**
+                    ```promql
+                    avg_over_time(
+                      rate(http_requests_total[5m])[1h:5m]
+                    )
+                    ```
+                    
+                    **Peak CPU usage over 24 hours:**
+                    ```promql
+                    max_over_time(
+                      sum(rate(node_cpu_seconds_total{mode!="idle"}[5m]))[24h:5m]
+                    )
+                    ```
+                    
+                    **Standard deviation of memory (volatility):**
+                    ```promql
+                    stddev_over_time(
+                      node_memory_MemAvailable_bytes[1h:5m]
+                    )
+                    ```
+                    
+<aside class="notes">
+Let's explore some practical subquery examples.
+
+The first example calculates a moving average of the request rate. This smooths out short-term fluctuations and gives you a cleaner view of your traffic trends. It's particularly useful for dashboards where you want to see the overall trend rather than moment-to-moment variations.
+
+The second example finds the peak CPU usage over the past 24 hours. This is valuable for capacity planning - it shows you the maximum load your system has experienced, which helps you understand headroom and plan for growth.
+
+The third example calculates the standard deviation of memory availability over the past hour. High standard deviation indicates volatile memory usage, which might suggest memory leaks, garbage collection issues, or bursty workloads.
+
+Some common functions used with subqueries:
+- avg_over_time: Smoothed averages
+- max_over_time / min_over_time: Peak/trough detection
+- stddev_over_time: Volatility measurement
+- quantile_over_time: Distribution analysis
+
+Remember that subqueries can be computationally expensive, especially with long ranges and short resolutions. Use them judiciously and consider recording rules for frequently-used subqueries.
+</aside>
+                </textarea>
+            </section>
+
+            <section data-markdown>
+                <textarea data-template>
+                    ## Subqueries for Trend Analysis
+                    
+                    **Detect if current value exceeds recent average:**
+                    ```promql
+                    rate(http_requests_total[5m]) 
+                    > 
+                    1.5 * avg_over_time(rate(http_requests_total[5m])[1h:5m])
+                    ```
+                    
+                    **Compare current to historical baseline:**
+                    ```promql
+                    sum(rate(node_cpu_seconds_total{mode!="idle"}[5m]))
+                    / 
+                    avg_over_time(
+                      sum(rate(node_cpu_seconds_total{mode!="idle"}[5m]))[24h:1h]
+                    )
+                    ```
+                    
+                    Returns ratio: >1 means above average, <1 means below
+                    
+<aside class="notes">
+Subqueries are particularly powerful for trend analysis and anomaly detection.
+
+The first example creates a simple anomaly detector: it triggers when the current request rate exceeds 1.5 times the average rate over the past hour. This is more sophisticated than a static threshold because it automatically adapts to your normal traffic patterns.
+
+The second example calculates a ratio of current CPU usage to the 24-hour average. A value greater than 1 means you're above your typical usage; less than 1 means you're below.
+
+This ratio approach is powerful because:
+- It normalizes across different systems (a busy server and a quiet one both show meaningful ratios)
+- It automatically adjusts as your baseline changes
+- It's easy to set alerts on (e.g., alert when ratio > 2)
+
+You can extend these patterns to create sophisticated alerts that account for:
+- Time-of-day patterns (by using offset with subqueries)
+- Weekly cycles (comparing to 7-day averages)
+- Growth trends (using deriv or predict_linear)
+
+These context-aware approaches significantly reduce alert fatigue compared to static thresholds.
+</aside>
+                </textarea>
+            </section>
+
+            <section data-markdown>
+                <textarea data-template>
+                    ## topk() and bottomk() Functions
+                    
+                    Identify the most significant outliers:
+                    
+                    ```promql
+                    # Top 5 CPU-consuming instances
+                    topk(5, 
+                      sum by (instance) (
+                        rate(node_cpu_seconds_total{mode!="idle"}[5m])
+                      )
+                    )
+                    
+                    # Bottom 3 available memory
+                    bottomk(3, node_memory_MemAvailable_bytes)
+                    ```
+                    
+                    * Returns k time series with highest/lowest values
+                    * Useful for dashboards and alerting on outliers
+                    
+<aside class="notes">
+The topk and bottomk functions help you focus on the most significant outliers in your metrics.
+
+topk returns the k time series with the highest values, while bottomk returns those with the lowest values.
+
+In the first example, we're finding the top 5 instances by CPU usage. This is perfect for a dashboard showing "busiest servers" or for alerting when specific instances are consuming more than their fair share of resources.
+
+In the second example, we're finding the 3 instances with the least available memory - these might be at risk of running out of memory and warrant attention.
+
+These functions are valuable because:
+- In large environments, you might have hundreds of instances - topk/bottomk helps focus attention
+- They make dashboards more actionable by highlighting what matters
+- They enable alerts like "notify me when any instance appears in the top 3 for errors"
+
+Note that topk and bottomk operate on the current instant value. If you want to find the top k based on an aggregate (like the average over time), combine them with subqueries.
+</aside>
+                </textarea>
+            </section>
+
+            <section data-markdown>
+                <textarea data-template>
+                    ## topk/bottomk Examples
+                    
+                    **Top error-producing endpoints:**
+                    ```promql
+                    topk(10, 
+                      sum by (handler) (
+                        rate(http_requests_total{status=~"5.."}[5m])
+                      )
+                    )
+                    ```
+                    
+                    **Instances with highest disk usage:**
+                    ```promql
+                    topk(5, 
+                      1 - (
+                        node_filesystem_avail_bytes{mountpoint="/"}
+                        / node_filesystem_size_bytes{mountpoint="/"}
+                      )
+                    )
+                    ```
+                    
+                    **Slowest growing metrics (potential issues):**
+                    ```promql
+                    bottomk(5, 
+                      rate(process_cpu_seconds_total[5m])
+                    )
+                    ```
+                    
+<aside class="notes">
+Let's explore some more sophisticated examples of topk and bottomk.
+
+The first example finds the top 10 error-producing endpoints by looking at HTTP requests with 5xx status codes. This immediately shows you which parts of your application are experiencing the most problems.
+
+The second example calculates disk usage percentage (1 minus the ratio of available to total bytes) and shows the top 5 most-full filesystems. This is crucial for capacity monitoring and preventing disk-full incidents.
+
+The third example uses bottomk to find processes with the lowest CPU growth rate. In some contexts, this might indicate stalled or hung processes that should be using CPU but aren't.
+
+Some best practices for topk/bottomk:
+- Choose k values that are meaningful for your team (top 5 is usually enough for dashboards)
+- Combine with sum by or other aggregations to group before ranking
+- Consider using these in recording rules if you need the results frequently
+- Remember that the ranking is recalculated at each evaluation, so the "top 5" can change over time
+
+These functions are especially powerful when combined with Grafana's table panels to create "leaderboard" style dashboards.
+</aside>
+                </textarea>
+            </section>
+
+            <section data-markdown>
+                <textarea data-template>
+                    ## The absent() Function
+                    
+                    Detect when expected metrics are missing:
+                    
+                    ```promql
+                    # Alert if node_exporter is not reporting
+                    absent(up{job="node-exporter"})
+                    
+                    # Returns 1 if no matching time series exists
+                    # Returns nothing if the metric exists
+                    ```
+                    
+                    Why it matters:
+                    * Detect failed exporters or scrapers
+                    * Identify configuration problems
+                    * "Monitor your monitoring"
+                    
+<aside class="notes">
+The absent function is crucial for what's often called "monitoring your monitoring" - ensuring that your metrics collection infrastructure is working correctly.
+
+absent takes a selector and returns 1 if no matching time series exist. If matching time series do exist, it returns nothing (an empty result).
+
+This might seem backwards at first - why would you want a function that returns something when data is missing? The answer is alerting. You want to be notified when expected metrics disappear, and alert rules fire when they have a result.
+
+Common use cases for absent include:
+
+Detecting failed exporters: If your node exporter stops running, the up metric will disappear. absent(up{job="node-exporter"}) will return 1, and you can alert on that.
+
+Identifying scrape failures: If Prometheus can't reach a target, the metrics will be absent. Using absent helps you detect this quickly.
+
+Configuration problems: If a new service is deployed but metrics aren't being collected, absent helps you catch this.
+
+The absent function is particularly valuable in dynamic environments where services come and go - it ensures you're alerted when expected services disappear entirely, not just when they're unhealthy.
+</aside>
+                </textarea>
+            </section>
+
+            <section data-markdown>
+                <textarea data-template>
+                    ## absent() Examples
+                    
+                    **Check for missing job:**
+                    ```promql
+                    absent(sum by (instance) (up{job="api-server"}))
+                    ```
+                    
+                    **Critical business metric check:**
+                    ```promql
+                    absent(orders_processed_total)
+                    ```
+                    
+                    **Comprehensive health check:**
+                    ```promql
+                    up{job="node-exporter"} == 0 
+                    or 
+                    absent(up{job="node-exporter"})
+                    ```
+                    
+                    Combines "down" detection with "missing" detection
+                    
+<aside class="notes">
+Let's explore some more nuanced examples of how the absent function can be used in real-world monitoring scenarios.
+
+The first example checks if any instances are missing for a specific job. By aggregating with sum by (instance) first, we ensure we're checking at the instance level. If no instances of the api-server job are being monitored at all, this returns 1.
+
+The second example focuses on business metrics rather than infrastructure. If a critical business metric like orders_processed_total is missing entirely, it might indicate an instrumentation problem or a serious issue with the order processing system.
+
+The third example shows the most comprehensive approach: combining an "up == 0" check with an absent check. This catches both scenarios:
+1. The service is reporting but unhealthy (up == 0)
+2. The service isn't reporting any metrics at all (absent returns 1)
+
+This pattern is recommended for critical services because it covers all failure modes.
+
+Some advanced patterns with absent:
+- Use with aggregations to check for expected label values
+- Combine with time functions for staleness checks
+- Include in recording rules to create composite health metrics
+
+Remember: absent is about detecting the complete absence of expected metrics, not detecting unhealthy values - that's what other comparison operators are for.
+</aside>
+                </textarea>
+            </section>
+
+            <section data-markdown>
+                <textarea data-template>
+                    ## Putting It All Together
+                    
+                    ```promql
+                    # Find instances with unusual CPU spikes
+                    topk(5,
+                      sum by (instance) (
+                        rate(node_cpu_seconds_total{mode!="idle"}[5m])
+                      ) 
+                      / 
+                      avg_over_time(
+                        sum by (instance) (
+                          rate(node_cpu_seconds_total{mode!="idle"}[5m])
+                        )[1h:5m]
+                      )
+                    )
+                    ```
+                    
+                    Combines:
+                    * **rate()** for CPU utilization
+                    * **Subquery** for historical baseline
+                    * **topk()** to find top offenders
+                    
+<aside class="notes">
+Let's look at a query that combines the techniques we've learned to solve a sophisticated monitoring challenge.
+
+This query identifies the top 5 instances that are experiencing the most unusual increase in CPU utilization compared to their recent history.
+
+Breaking it down:
+
+1. The inner rate calculates current CPU utilization per instance
+2. The subquery with avg_over_time calculates the average CPU utilization over the past hour
+3. The division creates a ratio: current / historical average
+4. The topk function returns the 5 instances with the highest ratios
+
+A ratio of 2.0 means "twice the normal CPU usage" - which is much more meaningful than an absolute percentage, because it accounts for each instance's normal behavior.
+
+This is an excellent example of context-aware monitoring:
+- An instance that normally runs at 10% but is now at 30% shows a ratio of 3.0
+- An instance that normally runs at 60% but is now at 75% shows a ratio of 1.25
+- The first instance is experiencing a more unusual situation, even though the second has higher absolute CPU
+
+This kind of analysis is only possible by combining subqueries with ranking functions.
+</aside>
+                </textarea>
+            </section>
+
+            <section data-markdown>
+                <textarea data-template>
+                    ## 🧪 Hands-On Exercise
+                    
+                    Try these queries in the Prometheus UI:
+                    
+                    **1. Average CPU rate over the last 10 minutes:**
+                    ```promql
+                    avg_over_time(
+                      sum(rate(node_cpu_seconds_total{mode!="idle"}[1m]))[10m:1m]
+                    )
+                    ```
+                    
+                    **2. Top 3 CPU modes by usage:**
+                    ```promql
+                    topk(3, sum by (mode) (rate(node_cpu_seconds_total[5m])))
+                    ```
+                    
+                    **3. Check if node exporter is reporting:**
+                    ```promql
+                    absent(node_cpu_seconds_total{instance="localhost:9100"})
+                    ```
+                    
+<aside class="notes">
+Let's put these concepts into practice with some hands-on exercises.
+
+Exercise 1 demonstrates a subquery to calculate the average CPU rate over the last 10 minutes, sampled every minute. This gives you a smoothed view of CPU utilization that filters out momentary spikes.
+
+Exercise 2 uses topk to find the top 3 CPU modes by usage. This quickly tells you where CPU time is being spent - is it mostly user, system, iowait, or something else?
+
+Exercise 3 tests the absent function. Since node_cpu_seconds_total should exist, this query should return no results (empty). If you change the instance to something that doesn't exist, you'll see it return 1.
+
+As you experiment:
+- Try different subquery ranges and resolutions
+- Change the k value in topk to see more or fewer results
+- Test absent with metrics you know exist and ones that don't
+
+These techniques are essential for sophisticated monitoring and will serve you well as you build more complex queries.
+</aside>
+                </textarea>
+            </section>
+
+            <section data-markdown>
+                <textarea data-template>
+                    ## Summary
+                    
+                    * **Subqueries** enable complex time-based analysis
+                      - Apply functions like avg_over_time to derived metrics
+                      - Create baselines and detect anomalies
+                    
+                    * **topk()/bottomk()** identify outliers
+                      - Focus dashboards on what matters most
+                      - Find top resource consumers or problem areas
+                    
+                    * **absent()** detects missing metrics
+                      - "Monitor your monitoring"
+                      - Catch failed exporters and scrape issues
+                    
+<aside class="notes">
+Let's summarize what we've learned in Lab 8b.
+
+Subqueries are one of the most powerful features in PromQL. They let you apply range vector functions to the results of any instant query, enabling sophisticated analysis like moving averages, peak detection, and baseline comparisons. Use them for trend analysis and anomaly detection, but be mindful of their computational cost.
+
+The topk and bottomk functions help you focus on what matters most. In environments with many instances, services, or endpoints, these functions cut through the noise to show you the most significant outliers. They're invaluable for dashboards and can also be used in alerts to notify you when specific items appear in the "top offenders" list.
+
+The absent function completes the picture by helping you detect when expected metrics are missing entirely. This is crucial for ensuring your monitoring infrastructure itself is healthy - you need to know when exporters fail, scrapes break, or configuration problems prevent metrics from being collected.
+
+Combined with the label manipulation and offset techniques from Lab 8a, you now have a comprehensive toolkit for advanced PromQL analysis. These techniques separate basic Prometheus users from experts and enable truly sophisticated monitoring solutions.
+</aside>
+                </textarea>
+            </section>
+
+            <section data-markdown>
+                <textarea data-template>
+                    # 🌟 Great job!
+                    
+                    Continue to Lab 9: Histograms and Quantiles
+                    
+                    <small>Navigate: [All Slides](../index.html) | [Previous Lab](../08a_Label_Manipulation_Offset/index.html) | [Next Lab](../09_Histograms_Quantiles/index.html)</small>
+                    
+<aside class="notes">
+Congratulations on completing Lab 8b! Combined with Lab 8a, you've now mastered the advanced PromQL techniques that enable sophisticated monitoring:
+
+From Lab 8a:
+- Label manipulation for reshaping your metrics
+- Offset modifier for historical comparisons
+
+From Lab 8b:
+- Subqueries for complex time-based analysis
+- topk/bottomk for outlier identification
+- absent for detecting missing metrics
+
+These techniques represent the transition from basic monitoring to sophisticated observability. You can now create context-aware alerts, perform detailed system analysis, and extract meaningful insights that go far beyond simple thresholds.
+
+In Lab 9, we'll explore histograms and quantiles - essential for understanding distributions, particularly for latency and response time metrics. These concepts will complete your PromQL toolkit and allow you to implement service level objectives.
+
+Before moving on, try combining the techniques from both 8a and 8b in creative ways. The real power comes from composing these functions together.
+</aside>
+                </textarea>
+            </section>
+        </div>
+    </div>
+    <!-- Include common scripts -->
+    <script src="../common-scripts.js"></script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -177,9 +177,22 @@
                         Advanced
                     </div>
                     <div class="card-body">
-                        <h5 class="card-title">Lab 8: Advanced PromQL Operations</h5>
-                        <p class="card-text">Master label manipulation, offset, subqueries, and ranking.</p>
-                        <a href="08_Advanced_PromQL_Operations/index.html" class="btn btn-danger">View Slides</a>
+                        <h5 class="card-title">Lab 8a: Label Manipulation & Offset</h5>
+                        <p class="card-text">Transform labels and compare metrics across time periods.</p>
+                        <a href="08a_Label_Manipulation_Offset/index.html" class="btn btn-danger">View Slides</a>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4">
+                <div class="card h-100">
+                    <div class="card-header bg-danger text-white">
+                        Advanced
+                    </div>
+                    <div class="card-body">
+                        <h5 class="card-title">Lab 8b: Subqueries, TopK & Absent</h5>
+                        <p class="card-text">Advanced time-series analysis and outlier detection.</p>
+                        <a href="08b_Subqueries_TopK_Absent/index.html" class="btn btn-danger">View Slides</a>
                     </div>
                 </div>
             </div>
@@ -196,7 +209,9 @@
                     </div>
                 </div>
             </div>
+        </div>
 
+        <div class="row mt-4">
             <div class="col-md-4">
                 <div class="card h-100">
                     <div class="card-header bg-danger text-white">


### PR DESCRIPTION
## Summary

This PR splits the monolithic Lab 8 slide deck into two separate decks to match the lab structure established in the curriculum-improvements branch.

## Changes

### New Slide Decks
- **docs/08a_Label_Manipulation_Offset/** - Covers label_replace, label_join, and offset modifier (11 slides)
- **docs/08b_Subqueries_TopK_Absent/** - Covers subqueries, topk/bottomk, and absent function (13 slides)

### Updated Files
- **docs/index.html** - Updated table of contents to show 8a and 8b as separate cards
- **docs/07_Recording_Rules_Alerting/index.html** - Updated navigation to link to 8a instead of original 08

### Quality
- Both new decks include comprehensive speaker notes (talk tracks)
- Consistent structure with other decks (Objectives, examples, hands-on exercises, Summary)
- Navigation links verified across all decks

## Related
- Complements the lab split done in PR #6 (curriculum-improvements branch)